### PR TITLE
Make a test independent of checkout location

### DIFF
--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,12 +1,16 @@
 import compiler from './compiler.js';
 
+const os = require('os');
+const path = require('path');
+
 test('Inserts name and outputs JavaScript', async () => {
   const stats = await compiler('main.go');
+  const pkgName = path.relative(path.join(process.env.GOPATH || path.join(os.homedir(), 'go'), 'src'), __dirname);
   const output = stats.toJson().modules[0].source;
   expect(output).toBe(
   `;(function() {
   var pkg = {};
-  pkg["../../workspace/projects/joy-loader/tests"] = (function() {
+  pkg["${pkgName}"] = (function() {
     function main () {
       console.log.apply(console.log, ["Hello!"])
     };
@@ -14,7 +18,7 @@ test('Inserts name and outputs JavaScript', async () => {
       main: main
     };
   })();
-  return pkg["../../workspace/projects/joy-loader/tests"].main();
+  return pkg["${pkgName}"].main();
 })()
 `);
 });


### PR DESCRIPTION
Joy is generating package name relative to `$GOPATH/src` (defaults to `$HOME/go` when `$GOPATH` is not set), so it depends on the project checkout location. This patch fix hardcoded author-dependent directory (package name) to dynamic one.